### PR TITLE
Separate create and cleanup commands

### DIFF
--- a/cmd/cleanup/command.go
+++ b/cmd/cleanup/command.go
@@ -1,0 +1,53 @@
+package cleanup
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "cleanup"
+	description = "Deletes a test cluster and associated release."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/cleanup/error.go
+++ b/cmd/cleanup/error.go
@@ -1,0 +1,21 @@
+package cleanup
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagError = &microerror.Error{
+	Kind: "invalidFlagError",
+}
+
+// IsInvalidFlag asserts invalidFlagError.
+func IsInvalidFlag(err error) bool {
+	return microerror.Cause(err) == invalidFlagError
+}

--- a/cmd/cleanup/flag.go
+++ b/cmd/cleanup/flag.go
@@ -1,12 +1,8 @@
 package cleanup
 
 import (
-	"fmt"
-
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
-
-	"github.com/giantswarm/standup/pkg/gsclient"
 )
 
 const (
@@ -14,7 +10,6 @@ const (
 	flagKubeconfig = "kubeconfig"
 	flagEndpoint   = "endpoint"
 	flagInCluster  = "in-cluster"
-	flagRelease    = "release"
 	flagToken      = "token"
 )
 
@@ -23,7 +18,6 @@ type flag struct {
 	Kubeconfig string
 	Endpoint   string
 	InCluster  bool
-	Release    string
 	Token      string
 }
 
@@ -32,16 +26,12 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the control plane.`)
 	cmd.Flags().StringVarP(&f.Endpoint, flagEndpoint, "n", "", `The endpoint of the target control plane's API.`)
 	cmd.Flags().BoolVarP(&f.InCluster, flagInCluster, "i", false, `True if this program is running in a Kubernetes cluster and should communicate with the API via the injected service account token.`)
-	cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", fmt.Sprintf(`The semantic version of the release to be tested.`))
 	cmd.Flags().StringVarP(&f.Token, flagToken, "t", "", `The token used to authenticate with the GS API.`)
 }
 
 func (f *flag) Validate() error {
 	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
 		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
-	}
-	if !gsclient.IsValidRelease(f.Release) {
-		return microerror.Maskf(invalidFlagError, "--%s must be a valid semantic version", flagRelease)
 	}
 
 	return nil

--- a/cmd/cleanup/flag.go
+++ b/cmd/cleanup/flag.go
@@ -1,0 +1,48 @@
+package cleanup
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/standup/pkg/gsclient"
+)
+
+const (
+	flagClusterID  = "cluster"
+	flagKubeconfig = "kubeconfig"
+	flagEndpoint   = "endpoint"
+	flagInCluster  = "in-cluster"
+	flagRelease    = "release"
+	flagToken      = "token"
+)
+
+type flag struct {
+	ClusterID  string
+	Kubeconfig string
+	Endpoint   string
+	InCluster  bool
+	Release    string
+	Token      string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.ClusterID, flagClusterID, "c", "", `The ID of the cluster to delete.`)
+	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the control plane.`)
+	cmd.Flags().StringVarP(&f.Endpoint, flagEndpoint, "n", "", `The endpoint of the target control plane's API.`)
+	cmd.Flags().BoolVarP(&f.InCluster, flagInCluster, "i", false, `True if this program is running in a Kubernetes cluster and should communicate with the API via the injected service account token.`)
+	cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", fmt.Sprintf(`The semantic version of the release to be tested.`))
+	cmd.Flags().StringVarP(&f.Token, flagToken, "t", "", `The token used to authenticate with the GS API.`)
+}
+
+func (f *flag) Validate() error {
+	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
+		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
+	}
+	if !gsclient.IsValidRelease(f.Release) {
+		return microerror.Maskf(invalidFlagError, "--%s must be a valid semantic version", flagRelease)
+	}
+
+	return nil
+}

--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -79,6 +79,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	// Get release version of tenant cluster
 	releaseVersion, err := gsClient.GetClusterReleaseVersion(context.Background(), r.flag.ClusterID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
 	// Delete tenant cluster
 	err = gsClient.DeleteCluster(context.Background(), r.flag.ClusterID)

--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -1,0 +1,85 @@
+package cleanup
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/standup/pkg/gsclient"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	// Create a GS API client for managing tenant clusters
+	var gsClient *gsclient.Client
+	{
+		c := gsclient.Config{
+			Logger: r.logger,
+
+			Endpoint: r.flag.Endpoint,
+			Token:    r.flag.Token,
+		}
+
+		var err error
+		gsClient, err = gsclient.New(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	// TODO: Will be used for cleaning up Release from CP
+	// Create REST config for the control plane
+	// var restConfig *rest.Config
+	// if r.flag.InCluster {
+	// 	var err error
+	// 	restConfig, err = rest.InClusterConfig()
+	// 	if err != nil {
+	// 		return microerror.Mask(err)
+	// 	}
+	// }
+
+	// Create clients for the control plane
+	// k8sClient, err := k8sclient.NewClients(k8sclient.ClientsConfig{
+	// 	Logger:         r.logger,
+	// 	KubeConfigPath: r.flag.Kubeconfig,
+	// 	RestConfig:     restConfig,
+	// })
+	// if err != nil {
+	// 	return microerror.Mask(err)
+	// }
+
+	// Clean up
+	err := gsClient.DeleteCluster(context.Background(), r.flag.ClusterID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// TODO: Delete release - need to pass or "remember" the random name
+
+	return nil
+}

--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -55,7 +55,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
-	// TODO: Will be used for cleaning up Release from CP
 	// Create REST config for the control plane
 	var restConfig *rest.Config
 	if r.flag.InCluster {

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -8,6 +8,8 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/standup/cmd/cleanup"
+	"github.com/giantswarm/standup/cmd/create"
 	"github.com/giantswarm/standup/cmd/test"
 	"github.com/giantswarm/standup/cmd/version"
 )
@@ -61,6 +63,34 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var createCmd *cobra.Command
+	{
+		c := create.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		createCmd, err = create.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cleanupCmd *cobra.Command
+	{
+		c := cleanup.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		cleanupCmd, err = cleanup.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var versionCmd *cobra.Command
 	{
 		c := version.Config{
@@ -97,6 +127,8 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
+	c.AddCommand(createCmd)
+	c.AddCommand(cleanupCmd)
 	c.AddCommand(testCmd)
 	c.AddCommand(versionCmd)
 

--- a/cmd/create/command.go
+++ b/cmd/create/command.go
@@ -1,0 +1,53 @@
+package create
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name        = "create"
+	description = "Creates a release and a tenant cluster in that release version."
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/create/error.go
+++ b/cmd/create/error.go
@@ -1,0 +1,21 @@
+package create
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagError = &microerror.Error{
+	Kind: "invalidFlagError",
+}
+
+// IsInvalidFlag asserts invalidFlagError.
+func IsInvalidFlag(err error) bool {
+	return microerror.Cause(err) == invalidFlagError
+}

--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -1,0 +1,52 @@
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/standup/pkg/gsclient"
+)
+
+const (
+	flagKubeconfig = "kubeconfig"
+	flagEndpoint   = "endpoint"
+	flagInCluster  = "in-cluster"
+	flagProvider   = "provider"
+	flagRelease    = "release"
+	flagToken      = "token"
+)
+
+type flag struct {
+	Kubeconfig string
+	Endpoint   string
+	InCluster  bool
+	Provider   string
+	Release    string
+	Token      string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the control plane.`)
+	cmd.Flags().StringVarP(&f.Endpoint, flagEndpoint, "n", "", `The endpoint of the target control plane's API.`)
+	cmd.Flags().BoolVarP(&f.InCluster, flagInCluster, "i", false, `True if this program is running in a Kubernetes cluster and should communicate with the API via the injected service account token.`)
+	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", fmt.Sprintf(`The provider of the target release. Possible values: <%s>`, strings.Join(gsclient.AllProviders(), "|")))
+	cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", fmt.Sprintf(`The semantic version of the release to be tested.`))
+	cmd.Flags().StringVarP(&f.Token, flagToken, "t", "", `The token used to authenticate with the GS API.`)
+}
+
+func (f *flag) Validate() error {
+	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
+		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
+	}
+	if !gsclient.IsValidProvider(f.Provider) {
+		return microerror.Maskf(invalidFlagError, "--%s must be one of <%s>", flagProvider, strings.Join(gsclient.AllProviders(), "|"))
+	}
+	if !gsclient.IsValidRelease(f.Release) {
+		return microerror.Maskf(invalidFlagError, "--%s must be a valid semantic version", flagRelease)
+	}
+
+	return nil
+}

--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -106,7 +106,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	// TODO: wait for the release to be ready
 
 	// Create the cluster under test
-	clusterID, err := gsClient.CreateCluster(context.Background(), r.flag.Release, r.flag.Provider)
+	clusterID, err := gsClient.CreateCluster(context.Background(), r.flag.Release)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -1,0 +1,128 @@
+package create
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strconv"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/standup/pkg/gsclient"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	// Create a GS API client for managing tenant clusters
+	var gsClient *gsclient.Client
+	{
+		c := gsclient.Config{
+			Logger: r.logger,
+
+			Endpoint: r.flag.Endpoint,
+			Token:    r.flag.Token,
+		}
+
+		var err error
+		gsClient, err = gsclient.New(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	// Create REST config for the control plane
+	var restConfig *rest.Config
+	if r.flag.InCluster {
+		var err error
+		restConfig, err = rest.InClusterConfig()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	// Create clients for the control plane
+	k8sClient, err := k8sclient.NewClients(k8sclient.ClientsConfig{
+		Logger:         r.logger,
+		KubeConfigPath: r.flag.Kubeconfig,
+		RestConfig:     restConfig,
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Read the Release CR from the filesystem
+	var release v1alpha1.Release
+	releaseYAML, err := ioutil.ReadFile("releases/" + r.flag.Provider + "/v" + r.flag.Release + "/release.yaml")
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Unmarshal the release
+	err = yaml.Unmarshal(releaseYAML, &release)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Randomize the name
+	release.Name = release.Name + "-" + strconv.Itoa(int(time.Now().Unix()))
+
+	// Create the Release CR
+	_, err = k8sClient.G8sClient().ReleaseV1alpha1().Releases().Create(context.Background(), &release, v1.CreateOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// TODO: wait for the release to be ready
+
+	// Create the cluster under test
+	clusterID, err := gsClient.CreateCluster(context.Background(), r.flag.Release, r.flag.Provider)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// TODO: Wait + backoff instead of just sleeping
+	// PKI backend needs some time after cluster creation
+	time.Sleep(5 * time.Second)
+
+	// Create a keypair for the new tenant cluster
+	kubeconfig, err := gsClient.GetKubeconfig(context.Background(), clusterID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// TODO: Store me somewhere
+	fmt.Println(len(kubeconfig))
+
+	return nil
+}

--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -106,7 +106,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	// TODO: wait for the release to be ready
 
 	// Create the cluster under test
-	clusterID, err := gsClient.CreateCluster(context.Background(), r.flag.Release, r.flag.Provider)
+	clusterID, err := gsClient.CreateCluster(context.Background(), r.flag.Release)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/gsclient/error.go
+++ b/pkg/gsclient/error.go
@@ -23,3 +23,12 @@ var clusterDeletionError = &microerror.Error{
 func IsClusterDeletionError(err error) bool {
 	return microerror.Cause(err) == clusterDeletionError
 }
+
+var clusterNotFoundError = &microerror.Error{
+	Kind: "clusterNotFoundError",
+}
+
+// IsClusterNotFoundError asserts clusterNotFoundError.
+func IsClusterNotFoundError(err error) bool {
+	return microerror.Cause(err) == clusterNotFoundError
+}

--- a/pkg/gsclient/gsclient.go
+++ b/pkg/gsclient/gsclient.go
@@ -46,22 +46,6 @@ type KubeconfigResponse struct {
 type ClusterEntry struct {
 	ID             string `json:"id"`
 	ReleaseVersion string `json:"release_version"`
-	// 	[
-	//   {
-	//     "create_date": "2020-08-06T16:23:47Z",
-	//     "id": "4jak7",
-	//     "labels": {
-	//       "cluster-operator.giantswarm.io/version": "2.3.2",
-	//       "giantswarm.io/cluster": "4jak7",
-	//       "giantswarm.io/organization": "conformance-testing",
-	//       "release.giantswarm.io/version": "12.1.0-1596731026"
-	//     },
-	//     "name": "Unnamed cluster",
-	//     "owner": "conformance-testing",
-	//     "path": "/v5/clusters/4jak7/",
-	//     "release_version": "12.1.0-1596731026"
-	//   }
-	// ]
 }
 
 const (


### PR DESCRIPTION
Breaks `standup create` and `standup cleanup` into separate commands

This relies on the cluster existing to know which release to delete. If cluster doesn't exist, it could leak the release. Let's talk about how to fix that separately, either by passing the release name as an argument or by naming them predictably

## Checklist

- [ ] Update changelog in CHANGELOG.md.
