### PR TITLE
Implement git diff, logs, and backoff

### DIFF
--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -2,12 +2,18 @@ package cleanup
 
 import (
 	"context"
+	"errors"
 	"io"
+	"time"
 
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
+
+	// v1 "k8s.io/client-go/1.5/pkg/api/v1"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
@@ -83,19 +89,71 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	// Delete tenant cluster
+	r.logger.LogCtx(context.Background(), "message", "beginning teardown")
+
+	r.logger.LogCtx(context.Background(), "message", "deleting cluster")
 	err = gsClient.DeleteCluster(context.Background(), r.flag.ClusterID)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	// Delete the release if we know which one to delete
-	if releaseVersion != "" {
-		err = k8sClient.G8sClient().ReleaseV1alpha1().Releases().Delete(context.Background(), releaseVersion, v1.DeleteOptions{})
+	// Wait for the cluster to be deleted
+	{
+		o := func() error {
+			clusters, err := gsClient.ListClusters(context.Background())
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+			for _, cluster := range clusters {
+				if cluster.ID == r.flag.ClusterID {
+					r.logger.LogCtx(context.Background(), "message", "waiting for cluster deletion")
+					return errors.New("waiting for cluster deletion")
+				}
+			}
+			return nil
+		}
+
+		b := backoff.NewMaxRetries(100, 20*time.Second)
+
+		err = backoff.Retry(o, b)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	}
+	r.logger.LogCtx(context.Background(), "message", "deleted cluster")
+
+	// Delete the Release CR
+	r.logger.LogCtx(context.Background(), "message", "deleting release CR")
+	backgroundDeletion := v1.DeletionPropagation("Background")
+	err = k8sClient.G8sClient().ReleaseV1alpha1().Releases().Delete(context.Background(), releaseVersion, v1.DeleteOptions{
+		PropagationPolicy: &backgroundDeletion,
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Wait for the release to be deleted
+	{
+		o := func() error {
+			_, err := k8sClient.G8sClient().ReleaseV1alpha1().Releases().Get(context.Background(), releaseVersion, v1.GetOptions{})
+			if errors2.IsNotFound(err) {
+				return nil
+			} else if err != nil {
+				return backoff.Permanent(err)
+			}
+			r.logger.LogCtx(context.Background(), "message", "waiting for release deletion")
+			return errors.New("waiting for release deletion")
+		}
+
+		b := backoff.NewMaxRetries(10, 20*time.Second)
+
+		err = backoff.Retry(o, b)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+	r.logger.LogCtx(context.Background(), "message", "deleted release CR")
+	r.logger.LogCtx(context.Background(), "message", "teardown complete")
 
 	return nil
 }

--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -11,8 +11,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
-
-	// v1 "k8s.io/client-go/1.5/pkg/api/v1"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"

--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -2,8 +2,10 @@ package create
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/standup/pkg/gsclient"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +14,7 @@ const (
 	flagEndpoint   = "endpoint"
 	flagInCluster  = "in-cluster"
 	flagProvider   = "provider"
+	flagRelease    = "release"
 	flagReleases   = "releases"
 	flagToken      = "token"
 )
@@ -20,6 +23,8 @@ type flag struct {
 	Kubeconfig string
 	Endpoint   string
 	InCluster  bool
+	Provider   string
+	Release    string
 	Releases   string
 	Token      string
 }
@@ -28,8 +33,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the control plane.`)
 	cmd.Flags().StringVarP(&f.Endpoint, flagEndpoint, "n", "", `The endpoint of the target control plane's API.`)
 	cmd.Flags().BoolVarP(&f.InCluster, flagInCluster, "i", false, `True if this program is running in a Kubernetes cluster and should communicate with the API via the injected service account token.`)
-	// cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", fmt.Sprintf(`The semantic version of the release to be tested.`))
-	cmd.Flags().StringVarP(&f.Releases, flagReleases, "r", "", fmt.Sprintf(`The path of the releases repo on the local filesystem.`))
+	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", fmt.Sprintf(`The provider of the target release. Possible values: <%s>`, strings.Join(gsclient.AllProviders(), "|")))
+	cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", fmt.Sprintf(`The semantic version of the release to be tested.`))
+	cmd.Flags().StringVarP(&f.Releases, flagReleases, "s", "", fmt.Sprintf(`The path of the releases repo on the local filesystem.`))
 	cmd.Flags().StringVarP(&f.Token, flagToken, "t", "", `The token used to authenticate with the GS API.`)
 }
 
@@ -37,9 +43,15 @@ func (f *flag) Validate() error {
 	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
 		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
 	}
-	// if !gsclient.IsValidRelease(f.Release) {
-	// 	return microerror.Maskf(invalidFlagError, "--%s must be a valid semantic version", flagRelease)
+	// if f.Release == "" && f.Releases == "" || f.Release != "" && f.Releases != "" {
+	// 	return microerror.Maskf(invalidFlagError, "must set exactly one of --%s or --%s", flagRelease, flagReleases)
 	// }
+	if f.Release != "" && !gsclient.IsValidRelease(f.Release) {
+		return microerror.Maskf(invalidFlagError, "--%s must be a valid semantic version", flagRelease)
+	}
+	if f.Release != "" && f.Provider == "" {
+		return microerror.Maskf(invalidFlagError, "must specify a valid provider when setting an exact release version")
+	}
 
 	return nil
 }

--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/standup/pkg/gsclient"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/standup/pkg/gsclient"
 )
 
 const (

--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -44,9 +44,9 @@ func (f *flag) Validate() error {
 	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
 		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
 	}
-	// if f.Release == "" && f.Releases == "" || f.Release != "" && f.Releases != "" {
-	// 	return microerror.Maskf(invalidFlagError, "must set exactly one of --%s or --%s", flagRelease, flagReleases)
-	// }
+	if f.Releases == "" {
+		return microerror.Maskf(invalidFlagError, "--%s is required", flagReleases)
+	}
 	if f.Release != "" && !gsclient.IsValidRelease(f.Release) {
 		return microerror.Maskf(invalidFlagError, "--%s must be a valid semantic version", flagRelease)
 	}

--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -250,7 +250,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(context.Background(), "message", "created cluster")
+	r.logger.LogCtx(context.Background(), "message", "created cluster %s", clusterID)
 
 	var kubeconfig string
 	r.logger.LogCtx(context.Background(), "message", "creating kubeconfig for cluster")
@@ -276,32 +276,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	r.logger.LogCtx(context.Background(), "message", "setup complete")
 
-	// // Create the Release CR
-	// _, err = k8sClient.G8sClient().ReleaseV1alpha1().Releases().Create(context.Background(), &release, v1.CreateOptions{})
-	// if err != nil {
-	// 	return microerror.Mask(err)
-	// }
-
-	// // TODO: wait for the release to be ready
-
-	// // Create the cluster under test
-	// clusterID, err := gsClient.CreateCluster(context.Background(), r.flag.Release)
-	// if err != nil {
-	// 	return microerror.Mask(err)
-	// }
-
-	// // TODO: Wait + backoff instead of just sleeping
-	// // PKI backend needs some time after cluster creation
-	// time.Sleep(5 * time.Second)
-
-	// // Create a keypair for the new tenant cluster
-	// kubeconfig, err := gsClient.GetKubeconfig(context.Background(), clusterID)
-	// if err != nil {
-	// 	return microerror.Mask(err)
-	// }
-
-	// // TODO: Store me somewhere
-	// fmt.Println(len(kubeconfig))
+	// TODO: Store kubeconfig somewhere
 
 	return nil
 }

--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -250,7 +250,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(context.Background(), "message", "created cluster %s", clusterID)
+	r.logger.LogCtx(context.Background(), "message", fmt.Sprintf("created cluster %s", clusterID))
 
 	var kubeconfig string
 	r.logger.LogCtx(context.Background(), "message", "creating kubeconfig for cluster")

--- a/cmd/test/flag.go
+++ b/cmd/test/flag.go
@@ -1,9 +1,6 @@
 package test
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
@@ -40,12 +37,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 func (f *flag) Validate() error {
 	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
 		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
-	}
-	if !gsclient.IsValidProvider(f.Provider) {
-		return microerror.Maskf(invalidFlagError, "--%s must be one of <%s>", flagProvider, strings.Join(gsclient.AllProviders(), "|"))
-	}
-	if !gsclient.IsValidRelease(f.Release) {
-		return microerror.Maskf(invalidFlagError, "--%s must be a valid semantic version", flagRelease)
 	}
 
 	return nil

--- a/cmd/test/flag.go
+++ b/cmd/test/flag.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/standup/pkg/gsclient"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/standup/pkg/gsclient"
 )
 
 const (

--- a/cmd/test/flag.go
+++ b/cmd/test/flag.go
@@ -1,18 +1,17 @@
 package test
 
 import (
+	"fmt"
+
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
-
-	"github.com/giantswarm/standup/pkg/gsclient"
 )
 
 const (
 	flagKubeconfig = "kubeconfig"
 	flagEndpoint   = "endpoint"
 	flagInCluster  = "in-cluster"
-	flagProvider   = "provider"
-	flagRelease    = "release"
+	flagReleases   = "releases"
 	flagToken      = "token"
 )
 
@@ -20,8 +19,7 @@ type flag struct {
 	Kubeconfig string
 	Endpoint   string
 	InCluster  bool
-	Provider   string
-	Release    string
+	Releases   string
 	Token      string
 }
 
@@ -29,14 +27,16 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the control plane.`)
 	cmd.Flags().StringVarP(&f.Endpoint, flagEndpoint, "n", "", `The endpoint of the target control plane's API.`)
 	cmd.Flags().BoolVarP(&f.InCluster, flagInCluster, "i", false, `True if this program is running in a Kubernetes cluster and should communicate with the API via the injected service account token.`)
-	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", fmt.Sprintf(`The provider of the target release. Possible values: <%s>`, strings.Join(gsclient.AllProviders(), "|")))
-	cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", fmt.Sprintf(`The semantic version of the release to be tested.`))
+	cmd.Flags().StringVarP(&f.Releases, flagReleases, "r", "", fmt.Sprintf(`The path of the releases repo on the local filesystem.`))
 	cmd.Flags().StringVarP(&f.Token, flagToken, "t", "", `The token used to authenticate with the GS API.`)
 }
 
 func (f *flag) Validate() error {
 	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
 		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
+	}
+	if f.Releases == "" {
+		return microerror.Maskf(invalidFlagError, "--%s is required", flagReleases)
 	}
 
 	return nil

--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -2,13 +2,17 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -41,6 +45,80 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func runGit(args []string, dir string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	return string(output), nil
+}
+
+// Tekton checks out the current commit in detached HEAD state with --depth=1.
+// This means we need to fetch origin/master before we can determine the changed files.
+func fetchAndDiff(dir string) (string, error) {
+	{
+		// Fetch master so we can diff against it
+		argsArr := []string{
+			"fetch",
+			"origin",
+			"master",
+		}
+		_, err := runGit(argsArr, dir)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	var diff string
+	{
+		// Determine the files added in this branch not in master
+		argsArr := []string{
+			"diff",
+			"--name-status",   // only show filename and the type of change (A=added, etc.)
+			"origin/master",   // diff against the latest master
+			"--diff-filter=A", // only show added files
+			"HEAD",            // base ref for the diff
+		}
+		var err error
+		diff, err = runGit(argsArr, dir)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return diff, nil
+}
+
+func findNewRelease(diff string) (releasePath string, provider string, release string, err error) {
+	{
+		lines := strings.Split(diff, "\n")
+		for _, line := range lines {
+			if strings.HasSuffix(line, "/release.yaml") {
+				fields := strings.Fields(line)
+				if len(fields) < 2 {
+					err = errors.New(fmt.Sprintf("incorrectly formatted diff: should look like 'A       aws/v13.0.0/release.yaml', found %s", line))
+					return
+				}
+				releasePath = fields[1]
+				break
+			}
+		}
+	}
+
+	if releasePath == "" {
+		err = errors.New("no new release found in this branch")
+		return
+	}
+
+	components := strings.Split(releasePath, "/")
+	provider = components[0]
+	release = components[1]
+
+	return
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
@@ -81,21 +159,39 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	// Read the Release CR from the filesystem
 	var release v1alpha1.Release
-	releaseYAML, err := ioutil.ReadFile("releases/" + r.flag.Provider + "/v" + r.flag.Release + "/release.yaml")
-	if err != nil {
-		return microerror.Mask(err)
-	}
+	var provider string
+	var releaseVersion string
+	{
+		// Use "git diff" to find the release under test
+		diff, err := fetchAndDiff(r.flag.Releases)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 
-	// Unmarshal the release
-	err = yaml.Unmarshal(releaseYAML, &release)
-	if err != nil {
-		return microerror.Mask(err)
-	}
+		// Parse the git diff to get the release file, version, and provider
+		var releasePath string
+		releasePath, provider, releaseVersion, err = findNewRelease(diff)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 
-	// Randomize the name
-	release.Name = release.Name + "-" + strconv.Itoa(int(time.Now().Unix()))
+		var release v1alpha1.Release
+		releaseYAML, err := ioutil.ReadFile(releasePath)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = yaml.Unmarshal(releaseYAML, &release)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// Randomize the name to avoid duplicate names
+		release.Name = release.Name + "-" + strconv.Itoa(int(time.Now().Unix()))
+		// Label for future garbage collection
+		release.Labels["giantswarm.io/testing"] = "true"
+	}
 
 	// Create the Release CR
 	_, err = k8sClient.G8sClient().ReleaseV1alpha1().Releases().Create(context.Background(), &release, v1.CreateOptions{})
@@ -103,10 +199,30 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	// TODO: wait for the release to be ready
+	// Wait for the created release to be ready
+	{
+		o := func() error {
+			r, err := k8sClient.G8sClient().ReleaseV1alpha1().Releases().Get(context.Background(), release.Name, v1.GetOptions{})
+			if err != nil {
+				return backoff.Permanent(err)
+			}
+			if !r.Status.Ready {
+				return errors.New("not ready")
+			}
+
+			return nil
+		}
+
+		b := backoff.NewMaxRetries(10, 20*time.Second)
+
+		err = backoff.Retry(o, b)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
 
 	// Create the cluster under test
-	clusterID, err := gsClient.CreateCluster(context.Background(), r.flag.Release, r.flag.Provider)
+	clusterID, err := gsClient.CreateCluster(context.Background(), releaseVersion, provider)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -166,21 +166,31 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var releaseVersion string
 	r.logger.LogCtx(context.Background(), "message", "determining release to test")
 	{
-		// Use "git diff" to find the release under test
-		diff, err := fetchAndDiff(r.flag.Releases)
-		if err != nil {
-			return microerror.Mask(err)
+		var releasePath string
+		{
+			if r.flag.Release != "" {
+				// Read the Release CR with the given version from the filesystem
+				releasePath = filepath.Join(r.flag.Releases, r.flag.Provider, "/v"+r.flag.Release, "/release.yaml")
+				provider = r.flag.Provider
+			} else {
+				// Use "git diff" to find the release under test
+				diff, err := fetchAndDiff(r.flag.Releases)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
+				// Parse the git diff to get the release file, version, and provider
+				releasePath, provider, err = findNewRelease(diff)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+				releasePath = filepath.Join(r.flag.Releases, releasePath)
+			}
 		}
 
-		// Parse the git diff to get the release file, version, and provider
-		var releasePath string
-		releasePath, provider, err = findNewRelease(diff)
-		if err != nil {
-			return microerror.Mask(err)
-		}
 		r.logger.LogCtx(context.Background(), "message", "determined target release to test is "+releasePath)
 
-		releaseYAML, err := ioutil.ReadFile(filepath.Join(r.flag.Releases, releasePath))
+		releaseYAML, err := ioutil.ReadFile(releasePath)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -242,7 +252,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(context.Background(), "message", "created cluster")
+	r.logger.LogCtx(context.Background(), "message", fmt.Sprintf("created cluster %s", clusterID))
 
 	var kubeconfig string
 	r.logger.LogCtx(context.Background(), "message", "creating kubeconfig for cluster")

--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -102,7 +102,7 @@ func findNewRelease(diff string) (releasePath string, provider string, err error
 			if strings.HasSuffix(line, "/release.yaml") {
 				fields := strings.Fields(line)
 				if len(fields) < 2 {
-					err = errors.New(fmt.Sprintf("incorrectly formatted diff: should look like 'A       aws/v13.0.0/release.yaml', found %s", line))
+					err = fmt.Errorf("incorrectly formatted diff: should look like 'A       aws/v13.0.0/release.yaml', found %s", line)
 					return
 				}
 				releasePath = fields[1]

--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -292,7 +292,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return nil
 		}
 
-		b := backoff.NewMaxRetries(10, 20*time.Second)
+		b := backoff.NewMaxRetries(100, 20*time.Second)
 
 		err = backoff.Retry(o, b)
 		if err != nil {

--- a/cmd/test/runner_test.go
+++ b/cmd/test/runner_test.go
@@ -10,7 +10,7 @@ A       aws/v13.0.0/release.diff
 A       aws/v13.0.0/release.yaml`
 
 func Test_findNewRelease(t *testing.T) {
-	path, provider, release, err := findNewRelease(diff)
+	path, provider, err := findNewRelease(diff)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,8 +19,5 @@ func Test_findNewRelease(t *testing.T) {
 	}
 	if provider != "aws" {
 		t.Errorf("expected aws, found %s", provider)
-	}
-	if release != "v13.0.0" {
-		t.Errorf("expected v13.0.0, found %s", release)
 	}
 }

--- a/cmd/test/runner_test.go
+++ b/cmd/test/runner_test.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"testing"
+)
+
+var diff = `A       aws/v13.0.0/README.md
+A       aws/v13.0.0/kustomization.yaml
+A       aws/v13.0.0/release.diff
+A       aws/v13.0.0/release.yaml`
+
+func Test_findNewRelease(t *testing.T) {
+	path, provider, release, err := findNewRelease(diff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "aws/v13.0.0/release.yaml" {
+		t.Errorf("expected aws/v13.0.0/release.yaml, found %s", path)
+	}
+	if provider != "aws" {
+		t.Errorf("expected aws, found %s", provider)
+	}
+	if release != "v13.0.0" {
+		t.Errorf("expected v13.0.0, found %s", release)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080
+	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v3 v3.1.3-0.20200724085258-345602646ea8
 	github.com/giantswarm/microerror v0.2.1
 	github.com/giantswarm/micrologger v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/giantswarm/standup
 go 1.14
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v3 v3.1.3-0.20200724085258-345602646ea8

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/standup
 go 1.14
 
 require (
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v3 v3.1.3-0.20200724085258-345602646ea8

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/giantswarm/standup
 go 1.14
 
 require (
-	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v3 v3.1.3-0.20200724085258-345602646ea8

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
-github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/gsclient/gsclient.go
+++ b/pkg/gsclient/gsclient.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
@@ -52,6 +53,19 @@ const (
 	CreationResultCreatedWithError = "created-with-errors"
 	DeletionResultScheduled        = "deletion scheduled"
 )
+
+var providers = []string{
+	"aws",
+}
+
+func AllProviders() []string {
+	return providers
+}
+
+func IsValidRelease(candidate string) bool {
+	_, err := semver.NewVersion(candidate)
+	return err == nil
+}
 
 func New(config Config) (*Client, error) {
 	if config.Logger == nil {

--- a/pkg/gsclient/gsclient.go
+++ b/pkg/gsclient/gsclient.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )


### PR DESCRIPTION
I checked how tekton clones the current git repo and made sure that the command I chose was compatible. It's basically:

- `git fetch`
- `git diff --name-status origin/master`

which gives us:

```
A       aws/v13.0.0/README.md
A       aws/v13.0.0/kustomization.yaml
A       aws/v13.0.0/release.diff
A       aws/v13.0.0/release.yaml
```
which can be parsed to determine that we're testing release 13.0.0 for AWS.

The code is still rough, I can clean it up before merging if you prefer, but wanted to get this code out so you're not blocked tomorrow.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
