### PR TITLE
Clone and build gsctl branch for use by standup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM quay.io/giantswarm/golang:1.14.7 AS gsctl
 RUN git clone https://github.com/giantswarm/gsctl.git
 WORKDIR /go/gsctl
 RUN git checkout add-json-output
-RUN go build
+RUN CGO_ENABLED=0 go build
 
 # Use the giantswarm alpine again when gsctl changes are merged
-# FROM quay.io/giantswarm/alpine:3.11-giantswarm as base
-FROM quay.io/giantswarm/golang:1.14.7 AS base
+FROM quay.io/giantswarm/alpine:3.11-giantswarm as base
 
 COPY --from=gsctl /go/gsctl/gsctl /usr/bin/gsctl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
-FROM quay.io/giantswarm/alpine:3.11-giantswarm
+# Need to build a branch of gsctl until changes are merged
+FROM quay.io/giantswarm/golang:1.14.7 AS gsctl
+RUN git clone https://github.com/giantswarm/gsctl.git
+WORKDIR /go/gsctl
+RUN git checkout add-json-output
+RUN go build
+
+# Use the giantswarm alpine again when gsctl changes are merged
+# FROM quay.io/giantswarm/alpine:3.11-giantswarm as base
+FROM quay.io/giantswarm/golang:1.14.7 AS base
+
+COPY --from=gsctl /go/gsctl/gsctl /usr/bin/gsctl
 
 ADD ./standup /standup
 


### PR DESCRIPTION
Building on `golang` and running on `alpine` has issues (I think related to architecture or dependencies) and I didn't want to go down a rabbit hole getting the build perfect for this temporary branch. 

As a result, the base for `standup` is `golang` until the `gsctl` changes are merged and built properly, but the intent is to revert this

## Checklist

- [ ] Update changelog in CHANGELOG.md.
