### PR TITLE
Write kubeconfig to path provided by --output flag

### DIFF
--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	defaultKubeconfigPath = "/workspace/output/kubeconfig"
+	defaultKubeconfigPath = "/workspace/cluster/kubeconfig"
 
 	flagKubeconfig = "kubeconfig"
 	flagEndpoint   = "endpoint"

--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -11,14 +11,15 @@ import (
 )
 
 const (
-	flagKubeconfig = "kubeconfig"
-	flagEndpoint   = "endpoint"
-	flagInCluster  = "in-cluster"
-	flagOutput     = "output"
-	flagProvider   = "provider"
-	flagRelease    = "release"
-	flagReleases   = "releases"
-	flagToken      = "token"
+	defaultKubeconfigPath = "/workspace/output/kubeconfig"
+	flagKubeconfig        = "kubeconfig"
+	flagEndpoint          = "endpoint"
+	flagInCluster         = "in-cluster"
+	flagOutput            = "output"
+	flagProvider          = "provider"
+	flagRelease           = "release"
+	flagReleases          = "releases"
+	flagToken             = "token"
 )
 
 type flag struct {
@@ -49,7 +50,7 @@ func (f *flag) Validate() error {
 	}
 	if f.OutputPath == "" {
 		// Set default output path if none is given
-		f.OutputPath = "/workspace/output/kubeconfig"
+		f.OutputPath = defaultKubeconfigPath
 	}
 	if f.Releases == "" {
 		return microerror.Maskf(invalidFlagError, "--%s is required", flagReleases)

--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -12,14 +12,15 @@ import (
 
 const (
 	defaultKubeconfigPath = "/workspace/output/kubeconfig"
-	flagKubeconfig        = "kubeconfig"
-	flagEndpoint          = "endpoint"
-	flagInCluster         = "in-cluster"
-	flagOutput            = "output"
-	flagProvider          = "provider"
-	flagRelease           = "release"
-	flagReleases          = "releases"
-	flagToken             = "token"
+
+	flagKubeconfig = "kubeconfig"
+	flagEndpoint   = "endpoint"
+	flagInCluster  = "in-cluster"
+	flagOutput     = "output"
+	flagProvider   = "provider"
+	flagRelease    = "release"
+	flagReleases   = "releases"
+	flagToken      = "token"
 )
 
 type flag struct {

--- a/cmd/create/flag.go
+++ b/cmd/create/flag.go
@@ -14,6 +14,7 @@ const (
 	flagKubeconfig = "kubeconfig"
 	flagEndpoint   = "endpoint"
 	flagInCluster  = "in-cluster"
+	flagOutput     = "output"
 	flagProvider   = "provider"
 	flagRelease    = "release"
 	flagReleases   = "releases"
@@ -25,6 +26,7 @@ type flag struct {
 	Endpoint   string
 	InCluster  bool
 	Provider   string
+	OutputPath string
 	Release    string
 	Releases   string
 	Token      string
@@ -34,6 +36,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the control plane.`)
 	cmd.Flags().StringVarP(&f.Endpoint, flagEndpoint, "n", "", `The endpoint of the target control plane's API.`)
 	cmd.Flags().BoolVarP(&f.InCluster, flagInCluster, "i", false, `True if this program is running in a Kubernetes cluster and should communicate with the API via the injected service account token.`)
+	cmd.Flags().StringVarP(&f.OutputPath, flagOutput, "o", "", fmt.Sprintf(`The path for storing the kubeconfig for the created cluster.`))
 	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", fmt.Sprintf(`The provider of the target release. Possible values: <%s>`, strings.Join(gsclient.AllProviders(), "|")))
 	cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", fmt.Sprintf(`The semantic version of the release to be tested.`))
 	cmd.Flags().StringVarP(&f.Releases, flagReleases, "s", "", fmt.Sprintf(`The path of the releases repo on the local filesystem.`))
@@ -43,6 +46,10 @@ func (f *flag) Init(cmd *cobra.Command) {
 func (f *flag) Validate() error {
 	if f.Kubeconfig == "" && !f.InCluster || f.Kubeconfig != "" && f.InCluster {
 		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagKubeconfig, flagInCluster)
+	}
+	if f.OutputPath == "" {
+		// Set default output path if none is given
+		f.OutputPath = "/workspace/output/kubeconfig"
 	}
 	if f.Releases == "" {
 		return microerror.Maskf(invalidFlagError, "--%s is required", flagReleases)

--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -278,5 +278,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	// TODO: Store kubeconfig somewhere
 
+	// Write to path from flag
+	err = ioutil.WriteFile(r.flag.OutputPath, []byte(kubeconfig), 0644)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }

--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -276,8 +276,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	r.logger.LogCtx(context.Background(), "message", "setup complete")
 
-	// TODO: Store kubeconfig somewhere
-
 	// Write to path from flag
 	err = ioutil.WriteFile(r.flag.OutputPath, []byte(kubeconfig), 0644)
 	if err != nil {


### PR DESCRIPTION
Kubeconfig will be stored at the path given by `--output`. If no value is given, the default location `/workspace/cluster/kubeconfig` will be used.

Towards https://github.com/giantswarm/giantswarm/issues/12553

## Checklist

- [ ] Update changelog in CHANGELOG.md.
