### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added logic for handling cluster creation errors that fail to create a cluster.
+
 [Unreleased]: https://github.com/giantswarm/standup/tree/master

--- a/pkg/gsclient/gsclient.go
+++ b/pkg/gsclient/gsclient.go
@@ -128,7 +128,7 @@ func (c *Client) CreateCluster(ctx context.Context, releaseVersion string) (stri
 		return "", microerror.Mask(err)
 	}
 
-	if response.Result == "error" {
+	if response.Result == CreationResultError {
 		return "", microerror.Maskf(clusterCreationError, output.String())
 	} else if response.Result == CreationResultCreatedWithError {
 		return response.ClusterID, microerror.Maskf(clusterCreationError, output.String())


### PR DESCRIPTION
Handles the case where `gsctl create cluster --output json` fails with an error `error` rather than `created-with-errors` which leads to an empty cluster ID and the following error in Tekton create-cluster step:
```
No cluster name or ID specified.
Please specify a cluster name or ID. Use --help for details.
```

Also removed some unused stderr handling since `--output json` seems to return errors to stdout.

## Checklist

- [x] Update changelog in CHANGELOG.md.
