### PR TITLE
Skip non-json output

### DIFF
--- a/pkg/gsclient/gsclient.go
+++ b/pkg/gsclient/gsclient.go
@@ -122,7 +122,7 @@ func (c *Client) CreateCluster(ctx context.Context, releaseVersion string) (stri
 	}
 
 	var response CreationResponse
-	err = json.Unmarshal(ignoreNonJSON(output.Bytes()), &response)
+	err = json.Unmarshal(ignoreWarnings(output.Bytes()), &response)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -145,7 +145,7 @@ func (c *Client) DeleteCluster(ctx context.Context, clusterID string) error {
 	}
 
 	var response DeletionResponse
-	err = json.Unmarshal(ignoreNonJSON(output.Bytes()), &response)
+	err = json.Unmarshal(ignoreWarnings(output.Bytes()), &response)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -167,7 +167,7 @@ func (c *Client) GetKubeconfig(ctx context.Context, clusterID string) (string, e
 	}
 
 	var response KubeconfigResponse
-	err = json.Unmarshal(ignoreNonJSON(output.Bytes()), &response)
+	err = json.Unmarshal(ignoreWarnings(output.Bytes()), &response)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -190,7 +190,7 @@ func (c *Client) ListClusters(ctx context.Context) ([]ClusterEntry, error) {
 	}
 
 	var response []ClusterEntry
-	err = json.Unmarshal(ignoreNonJSON(output.Bytes()), &response)
+	err = json.Unmarshal(ignoreWarnings(output.Bytes()), &response)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -215,9 +215,6 @@ func (c *Client) GetClusterReleaseVersion(ctx context.Context, clusterID string)
 	return "", microerror.Maskf(clusterNotFoundError, fmt.Sprintf("cluster %s was not found", clusterID))
 }
 
-func ignoreNonJSON(input []byte) []byte {
-	openingBracketIndex := strings.Index(string(input), "{")
-	closingBracketIndex := strings.LastIndex(string(input), "}")
-
-	return input[openingBracketIndex : closingBracketIndex+1]
+func ignoreWarnings(input []byte) []byte {
+	return bytes.ReplaceAll(input, []byte("Warning:*\n"), []byte{})
 }

--- a/pkg/gsclient/gsclient.go
+++ b/pkg/gsclient/gsclient.go
@@ -221,7 +221,7 @@ func ignoreNonJSON(input []byte) []byte {
 
 	if curlyBracketIndex == -1 {
 		// Input is not a JSON
-		return []byte{}
+		return nil
 	}
 
 	if squareBracketIndex == -1 {


### PR DESCRIPTION
So the JSON could also be an array and start with [. This is hacky and will break if there are brackets in the pre-json output so I'm open for ideas. 
I tried ignoring the warnings only, but it turns out that gscliauth talks a lot more than that. We could also change stdout in gsctl temporarily, but it doesn't sound less hacky. This is a temporarily solution until we find a better way to do it.  