### PR TITLE
Remove gsctl build step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Modified `gsctl` execution to use the binary from the current `$PATH`.
+- Use `gsctl` version 0.24.0
 
 ### Removed
 


### PR DESCRIPTION
This PR changes the Dockerfile to use the binary release of gsctl.

## Checklist

- [x] Update changelog in CHANGELOG.md.
