### PR TITLE
use --self-contained of gsctl for creating kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Modified `gsctl` execution to use the binary from the current `$PATH`.
 - Use `gsctl` version 0.24.0
+- Let `gsctl` write the kubeconfig directly
 
 ### Removed
 

--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -253,12 +253,11 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 	}
 	r.logger.LogCtx(ctx, "message", fmt.Sprintf("created cluster %s", clusterID))
 
-	var kubeconfig string
-	r.logger.LogCtx(ctx, "message", "creating kubeconfig for cluster")
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("creating and writing kubeconfig for cluster %s to path %s", clusterID, r.flag.OutputKubeconfig))
 	{
 		o := func() error {
-			// Create a keypair for the new tenant cluster
-			kubeconfig, err = gsClient.GetKubeconfig(ctx, clusterID)
+			// Create a keypair and kubeconfig for the new tenant cluster
+			err = gsClient.CreateKubeconfig(ctx, clusterID, r.flag.OutputKubeconfig)
 			if err != nil {
 				// TODO: check to see if it's a permanent error or the kubeconfig just isn't ready yet
 				r.logger.LogCtx(ctx, "message", "error creating kubeconfig", "error", err)
@@ -273,13 +272,6 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-	}
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("created kubeconfig with length %d", len(kubeconfig)))
-
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("writing kubeconfig to path %s", r.flag.OutputKubeconfig))
-	err = ioutil.WriteFile(r.flag.OutputKubeconfig, []byte(kubeconfig), 0644)
-	if err != nil {
-		return microerror.Mask(err)
 	}
 
 	r.logger.LogCtx(ctx, "message", fmt.Sprintf("writing cluster ID to path %s", r.flag.OutputClusterID))

--- a/pkg/gsclient/gsclient.go
+++ b/pkg/gsclient/gsclient.go
@@ -38,11 +38,6 @@ type DeletionResponse struct {
 	Result    string `json:"result"`
 }
 
-type KubeconfigResponse struct {
-	Kubeconfig string `json:"kubeconfig"`
-	Result     string `json:"result"`
-}
-
 type ClusterEntry struct {
 	ID             string `json:"id"`
 	ReleaseVersion string `json:"release_version"`
@@ -157,28 +152,17 @@ func (c *Client) DeleteCluster(ctx context.Context, clusterID string) error {
 	return nil
 }
 
-func (c *Client) GetKubeconfig(ctx context.Context, clusterID string) (string, error) {
+func (c *Client) CreateKubeconfig(ctx context.Context, clusterID, kubeconfigPath string) error {
 
 	// TODO: extract and structure all these hardcoded values
-	args := fmt.Sprintf("--output=json create kubeconfig --cluster=%s --certificate-organizations system:masters", clusterID)
-	output, err := c.runWithGsctl(args)
+	args := fmt.Sprintf("create kubeconfig --cluster=%s --certificate-organizations system:masters --force --self-contained %s", clusterID, kubeconfigPath)
+
+	_, err := c.runWithGsctl(args)
 	if err != nil {
-		return "", microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	var response KubeconfigResponse
-	err = json.Unmarshal(ignoreNonJSON(output.Bytes()), &response)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	// TODO: Do something useful here or remove it
-	if response.Result != "ok" {
-		fmt.Println("something went wrong creating kubeconfig")
-		fmt.Println(output)
-	}
-
-	return response.Kubeconfig, nil
+	return nil
 }
 
 func (c *Client) ListClusters(ctx context.Context) ([]ClusterEntry, error) {


### PR DESCRIPTION
This PR changes the usage of `gsctl create kubeconfig` to let `gsctl` write the kubeconfig file directly to the specified path.

## Checklist

- [x] Update changelog in CHANGELOG.md.
