### PR TITLE
Fix provider flag

### DIFF
--- a/cmd/cleanup/flag.go
+++ b/cmd/cleanup/flag.go
@@ -23,7 +23,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.ClusterID, flagClusterID, "c", "", `The ID of the cluster to delete.`)
 	cmd.Flags().StringVarP(&f.Config, flagConfig, "g", "", `The path to the file containing API endpoints and tokens for each provider.`)
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the control plane.`)
-	cmd.Flags().StringVarP(&f.Provider, flagProvider, "k", "", `The path to the kubeconfig for the control plane.`)
+	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", `The provider of the cluster to delete.`)
 }
 
 func (f *flag) Validate() error {


### PR DESCRIPTION
Privider flag was a copy/paste of the kubeconfig one so there are two flags defined as -k
