### PR TITLE
Diff against the merge base

### DIFF
--- a/cmd/create/runner.go
+++ b/cmd/create/runner.go
@@ -96,8 +96,13 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 					return microerror.Mask(err)
 				}
 
+				mergeBase, err := git.MergeBase(r.flag.Releases)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+
 				// Use "git diff" to find the release under test
-				diff, err := git.Diff(r.flag.Releases)
+				diff, err := git.Diff(r.flag.Releases, mergeBase)
 				if err != nil {
 					return microerror.Mask(err)
 				}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -2,16 +2,17 @@ package git
 
 import (
 	"os/exec"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 )
 
-func Diff(dir string) (string, error) {
+func Diff(dir, ref string) (string, error) {
 	// Determine the files added in this branch not in master
 	argsArr := []string{
 		"diff",
 		"--name-status",   // only show filename and the type of change (A=added, etc.)
-		"origin/master",   // diff against the latest master
+		ref,               // diff against the passed reference
 		"--diff-filter=A", // only show added files
 		"--no-renames",    // disable rename detection so we always find new releases
 		"HEAD",            // base ref for the diff
@@ -36,6 +37,21 @@ func Fetch(dir string) error {
 		return microerror.Mask(err)
 	}
 	return nil
+}
+
+func MergeBase(dir string) (string, error) {
+	// Fetch master so we can diff against it
+	argsArr := []string{
+		"merge-base",
+		"HEAD",
+		"origin/master",
+	}
+	mergeBase, err := runGit(argsArr, dir)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return strings.TrimSpace(mergeBase), nil
 }
 
 func runGit(args []string, dir string) (string, error) {


### PR DESCRIPTION
If someone deletes a file (for example archiving a release) in master then the current version of diff will show the archived files as new and we will end up choosing the wrong release to deploy. By getting the diff from the merge base, we guarantee that we only get the new files from our PR. 
