### PR TITLE
Refine test release name generation for test releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improve test release name generation to work with alpha / beta releases.
+
 ## [1.1.0] - 2020-10-21
 
 ### Changed

--- a/cmd/create/release/runner_test.go
+++ b/cmd/create/release/runner_test.go
@@ -1,7 +1,11 @@
 package release
 
 import (
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 var diff = `A       aws/v13.0.0/README.md
@@ -19,5 +23,48 @@ func Test_findNewRelease(t *testing.T) {
 	}
 	if provider != "aws" {
 		t.Errorf("expected aws, found %s", provider)
+	}
+}
+
+func Test_generateReleaseName(t *testing.T) {
+	t.Skip("timing sensitive tests; only enable on-demand locally")
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "case 0: simple release version",
+			input:    "v13.0.0",
+			expected: "v13.0.0-" + strconv.Itoa(int(time.Now().Unix())),
+		},
+		{
+			name:     "case 1: alpha release version",
+			input:    "v13.0.0-alpha3",
+			expected: "v13.0.0-" + strconv.Itoa(int(time.Now().Unix())),
+		},
+		{
+			name:     "case 2: beta release version",
+			input:    "v13.0.0-beta1",
+			expected: "v13.0.0-" + strconv.Itoa(int(time.Now().Unix())),
+		},
+		{
+			name:     "case 3: non-standard release version",
+			input:    "v13.0",
+			expected: "v13.0-" + strconv.Itoa(int(time.Now().Unix())),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			output := generateReleaseName(tc.input)
+
+			if !cmp.Equal(output, tc.expected) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(tc.expected, output))
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/giantswarm/microerror v0.2.1
 	github.com/giantswarm/micrologger v0.3.1
 	github.com/go-openapi/runtime v0.19.20 // indirect
+	github.com/google/go-cmp v0.5.1
 	github.com/spf13/cobra v1.0.0
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6


### PR DESCRIPTION
When testing alpha / beta releases, the generated release name requires
special handling in order to comply with release name validation rules.

## Checklist

- [x] Update changelog in CHANGELOG.md.
