### PR TITLE
Wait for external-dns in wait task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Wait for `external-dns` on AWS and Azure in `wait` task.
+
 ## [2.0.0] - 2020-11-18
 
 ### Changed

--- a/cmd/wait/flag.go
+++ b/cmd/wait/flag.go
@@ -7,19 +7,25 @@ import (
 
 const (
 	flagKubeconfig = "kubeconfig"
+	flagProvider   = "provider"
 )
 
 type flag struct {
 	Kubeconfig string
+	Provider   string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the tenant cluster.`)
+	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", `The provider of the target control plane.`)
 }
 
 func (f *flag) Validate() error {
 	if f.Kubeconfig == "" {
 		return microerror.Maskf(invalidFlagError, "--%s is required", flagKubeconfig)
+	}
+	if f.Provider == "" {
+		return microerror.Maskf(invalidFlagError, "--%s is required", flagProvider)
 	}
 
 	return nil

--- a/cmd/wait/runner.go
+++ b/cmd/wait/runner.go
@@ -199,5 +199,65 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		r.logger.LogCtx(ctx, "message", "CoreDNS is ready")
 	}
 
+	if r.flag.Provider != "KVM" {
+		r.logger.LogCtx(ctx, "message", "waiting for external-dns to be ready")
+
+		targetLabels := map[string]string{
+			"giantswarm.io/service-type": "managed",
+			"app.kubernetes.io/name":     "external-dns",
+		}
+
+		o := func() error {
+			serviceLabelSelector := labelsToSelector(targetLabels)
+			services, err := k8sClient.CoreV1().Services("kube-system").List(ctx, v1.ListOptions{
+				LabelSelector: serviceLabelSelector,
+			})
+			if err != nil {
+				r.logger.LogCtx(ctx, "message", "error listing services", "error", err)
+				return microerror.Mask(err)
+			}
+			if len(services.Items) == 0 {
+				message := fmt.Sprintf("external-dns service not found using label selector %#q", serviceLabelSelector)
+				r.logger.LogCtx(ctx, "message", message)
+				return microerror.Mask(notReadyError)
+			}
+
+			service := services.Items[0]
+			podLabelSelector := labelsToSelector(service.Spec.Selector)
+			pods, err := k8sClient.CoreV1().Pods("kube-system").List(ctx, v1.ListOptions{
+				LabelSelector: podLabelSelector,
+			})
+			if err != nil {
+				r.logger.LogCtx(ctx, "message", "error listing external-dns pods", "error", err)
+				return microerror.Mask(err)
+			}
+			if len(pods.Items) == 0 {
+				message := fmt.Sprintf("external-dns pods not found using label selector %#q", podLabelSelector)
+				r.logger.LogCtx(ctx, "message", message)
+				return microerror.Mask(notReadyError)
+			}
+
+			for _, pod := range pods.Items {
+				for _, container := range pod.Status.ContainerStatuses {
+					if !container.Ready {
+						message := fmt.Sprintf("external-dns pod container %#q not ready", container.Name)
+						r.logger.LogCtx(ctx, "message", message)
+						return microerror.Mask(notReadyError)
+					}
+				}
+			}
+
+			return nil
+		}
+		// Retry basically forever, the tekton task will determine maximum runtime.
+		b := backoff.NewMaxRetries(^uint64(0), 20*time.Second)
+
+		err = backoff.Retry(o, b)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		r.logger.LogCtx(ctx, "message", "external-dns is ready")
+	}
+
 	return nil
 }

--- a/cmd/wait/runner.go
+++ b/cmd/wait/runner.go
@@ -199,7 +199,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		r.logger.LogCtx(ctx, "message", "CoreDNS is ready")
 	}
 
-	if r.flag.Provider != "KVM" {
+	if r.flag.Provider != "kvm" {
 		r.logger.LogCtx(ctx, "message", "waiting for external-dns to be ready")
 
 		targetLabels := map[string]string{

--- a/cmd/wait/runner.go
+++ b/cmd/wait/runner.go
@@ -199,6 +199,9 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		r.logger.LogCtx(ctx, "message", "CoreDNS is ready")
 	}
 
+	// We wait for external-dns for Azure and AWS. This prevents failures where
+	// the CNCF suit is started before external-dns is functional.
+	// This is not necessary on KVM as there is no external-dns app running.
 	if r.flag.Provider != "kvm" {
 		r.logger.LogCtx(ctx, "message", "waiting for external-dns to be ready")
 


### PR DESCRIPTION
This adds a wait for `external-dns` on our two cloud providers. Please check and voice opinions if you think this makes sense.


## Checklist

- [x] Update changelog in CHANGELOG.md.
