### PR TITLE
Tidy up some TODOs

### DIFF
--- a/cmd/create/cluster/runner.go
+++ b/cmd/create/cluster/runner.go
@@ -98,7 +98,6 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			// Create a keypair and kubeconfig for the new tenant cluster
 			err := gsClient.CreateKubeconfig(ctx, clusterID, kubeconfigPath)
 			if err != nil {
-				// TODO: check to see if it's a permanent error or the kubeconfig just isn't ready yet
 				r.logger.LogCtx(ctx, "message", "error creating kubeconfig", "error", err)
 				return microerror.Mask(err)
 			}

--- a/pkg/gsclient/cluster.go
+++ b/pkg/gsclient/cluster.go
@@ -15,9 +15,15 @@ func (c *Client) CreateCluster(ctx context.Context, releaseVersion string) (stri
 		return "", microerror.Mask(err)
 	}
 
+	createOptions := GsctlCreateClusterOptions{
+		OutputType: OutputTypeJSON,
+		Owner:      key.ClusterOwnerName,
+		Name:       releaseVersion,
+		Release:    releaseVersion,
+	}
+
 	var response CreationResponse
-	// TODO: extract and structure all these hardcoded values
-	output, err := c.runWithGsctlJSON(ctx, &response, "--output=json", "create", "cluster", "--owner", "conformance-testing", "--name", releaseVersion, "--release", releaseVersion)
+	output, err := c.gsctlCreateCluster(ctx, &response, createOptions)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -37,9 +43,13 @@ func (c *Client) DeleteCluster(ctx context.Context, clusterID string) error {
 		return microerror.Mask(err)
 	}
 
+	deleteOptions := GsctlDeleteClusterOptions{
+		OutputType: OutputTypeJSON,
+		ID:         clusterID,
+	}
+
 	var response DeletionResponse
-	// TODO: extract and structure all these hardcoded values
-	output, err := c.runWithGsctlJSON(ctx, &response, "--output=json", "delete", "cluster", clusterID)
+	output, err := c.gsctlDeleteCluster(ctx, &response, deleteOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -81,8 +91,13 @@ func (c *Client) ListClusters(ctx context.Context) ([]ClusterEntry, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	listOptions := GsctlListClustersOptions{
+		OutputType:   OutputTypeJSON,
+		ShowDeleting: true,
+	}
+
 	var response []ClusterEntry
-	_, err = c.runWithGsctlJSON(ctx, &response, "--output=json", "list", "clusters", "--show-deleting")
+	_, err = c.gsctlListClusters(ctx, &response, listOptions)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/pkg/gsclient/types.go
+++ b/pkg/gsclient/types.go
@@ -5,13 +5,11 @@ type ClusterEntry struct {
 	ReleaseVersion string `json:"release_version"`
 }
 
-// TODO: Use the gsctl type directly
 type CreationResponse struct {
 	ClusterID string `json:"id"`
 	Result    string `json:"result"`
 }
 
-// TODO: Use the gsctl type directly
 type DeletionResponse struct {
 	ClusterID string `json:"id"`
 	Result    string `json:"result"`

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -2,6 +2,10 @@ package key
 
 import "fmt"
 
+const (
+	ClusterOwnerName = "conformance-testing"
+)
+
 func KubeconfigPath(base, provider string) (path string) {
 	return fmt.Sprintf("%s/%s", base, provider)
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13569

Removes/centralizes duplicate gsctl command line calls, and cleans up a couple TODO comments we no longer need.

The idea is just to reduce how many places we have duplicated flag values and add a little more structure on top of the raw gsctl calls.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
