### PR TITLE
Install jq in the Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `jq` installed in Docker image.
+
 ## [2.1.0] - 2020-11-30
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/giantswarm/alpine:3.12 AS binaries
 ARG KUBECTL_VERSION=1.18.9
 ARG GSCTL_VERSION=0.24.4
 
-RUN apk add --no-cache ca-certificates curl \
+RUN apk add --no-cache ca-certificates curl jq \
     && mkdir -p /binaries \
     && curl -SL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /binaries/kubectl \
     && curl -SL https://github.com/giantswarm/gsctl/releases/download/${GSCTL_VERSION}/gsctl-${GSCTL_VERSION}-linux-amd64.tar.gz | \


### PR DESCRIPTION
I need to use `jq` from our tekton pipelines before calling `standup` , so it would be convenient if the Docker image would already contain `jq`.

## Checklist

- [X] Update changelog in CHANGELOG.md.
