### PR TITLE
Add `--mode` flag to the `create release` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--mode` flag to the `create release` command to customize how the release CR is created. Needed to trigger the command from the `azure-operator` repo.
+
 ## [2.1.0] - 2020-11-30
 
 ### Changed

--- a/cmd/create/release/error.go
+++ b/cmd/create/release/error.go
@@ -20,15 +20,6 @@ func IsInvalidFlag(err error) bool {
 	return microerror.Cause(err) == invalidFlagError
 }
 
-var invalidRepositoryError = &microerror.Error{
-	Kind: "invalidRepositoryError",
-}
-
-// IsInvalidRepository asserts invalidRepositoryError.
-func IsInvalidRepository(err error) bool {
-	return microerror.Cause(err) == invalidRepositoryError
-}
-
 var releaseNotFoundError = &microerror.Error{
 	Kind: "releaseNotFoundError",
 }

--- a/cmd/create/release/error.go
+++ b/cmd/create/release/error.go
@@ -20,6 +20,15 @@ func IsInvalidFlag(err error) bool {
 	return microerror.Cause(err) == invalidFlagError
 }
 
+var invalidRepositoryError = &microerror.Error{
+	Kind: "invalidRepositoryError",
+}
+
+// IsInvalidRepository asserts invalidRepositoryError.
+func IsInvalidRepository(err error) bool {
+	return microerror.Cause(err) == invalidRepositoryError
+}
+
 var releaseNotFoundError = &microerror.Error{
 	Kind: "releaseNotFoundError",
 }

--- a/cmd/create/release/flag.go
+++ b/cmd/create/release/flag.go
@@ -6,32 +6,47 @@ import (
 )
 
 const (
-	flagConfig     = "config"
-	flagKubeconfig = "kubeconfig"
-	flagOutput     = "output"
-	flagReleases   = "releases"
+	flagAzureOperator = "azure-operator"
+	flagConfig        = "config"
+	flagKubeconfig    = "kubeconfig"
+	flagMode          = "mode"
+	flagOutput        = "output"
+	flagReleases      = "releases"
+
+	modeReleases      = "releases"
+	modeAzureOperator = "azure-operator"
 )
 
 type flag struct {
-	Config     string
-	Kubeconfig string
-	Output     string
-	Releases   string
+	AzureOperator string
+	Config        string
+	Kubeconfig    string
+	Mode          string
+	Output        string
+	Releases      string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.AzureOperator, flagAzureOperator, "", "", `The path to the file containing API endpoints and tokens for each provider.`)
 	cmd.Flags().StringVarP(&f.Config, flagConfig, "g", "", `The path to the file containing API endpoints and tokens for each provider.`)
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the directory containing the kubeconfigs for provider control planes.`)
+	cmd.Flags().StringVar(&f.Mode, flagMode, "releases", `The mode to be used to create the release: either 'releases' or 'azure-operator'.`)
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", `The directory in which to store the release name of the created release.`)
 	cmd.Flags().StringVarP(&f.Releases, flagReleases, "s", "", `The path of the releases repo on the local filesystem.`)
 }
 
 func (f *flag) Validate() error {
+	if f.Mode == modeAzureOperator && f.AzureOperator == "" {
+		return microerror.Maskf(invalidFlagError, "--%s is required when --mode is set to %s", flagAzureOperator, modeAzureOperator)
+	}
 	if f.Config == "" {
 		return microerror.Maskf(invalidFlagError, "--%s is required", flagConfig)
 	}
 	if f.Kubeconfig == "" {
 		return microerror.Maskf(invalidFlagError, "--%s is required", flagKubeconfig)
+	}
+	if f.Mode != modeReleases && f.Mode != modeAzureOperator {
+		return microerror.Maskf(invalidFlagError, "--%s can either be %q or %q. %q was provided", flagMode, modeReleases, modeAzureOperator, f.Mode)
 	}
 	if f.Output == "" {
 		return microerror.Maskf(invalidFlagError, "--%s is required", flagOutput)

--- a/cmd/create/release/mode_azureoperator.go
+++ b/cmd/create/release/mode_azureoperator.go
@@ -1,0 +1,114 @@
+package release
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/standup/pkg/git"
+)
+
+func (r *runner) generateReleaseFromAzureOperatorRepo(ctx context.Context) (*v1alpha1.Release, string, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "Generating test Release CR using azure-operator mode")
+	var release v1alpha1.Release
+	provider := "azure"
+
+	// Find latest release in the releases repo.
+	r.logger.LogCtx(ctx, "message", "determining latest release")
+	var releasePath string
+	{
+		entries, err := ioutil.ReadDir(filepath.Join(r.flag.Releases, provider))
+		if err != nil {
+			return nil, "", microerror.Mask(err)
+		}
+
+		var latest *semver.Version
+
+		for _, f := range entries {
+			if !f.IsDir() || f.Name() == "." || f.Name() == ".." || f.Name() == "archived" {
+				continue
+			}
+
+			// Try to parse version.
+			version, err := semver.Parse(strings.TrimPrefix(f.Name(), "v"))
+			if err != nil {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Unable to parse semver version from %q", f.Name()))
+				continue
+			}
+
+			if latest == nil || version.GT(*latest) {
+				latest = &version
+			}
+		}
+
+		if latest == nil {
+			return nil, "", microerror.Maskf(releaseNotFoundError, "Can't find a valid release")
+		}
+
+		r.logger.LogCtx(ctx, "message", fmt.Sprintf("latest release is %s", latest.String()))
+
+		releasePath = filepath.Join(r.flag.Releases, provider, fmt.Sprintf("v%s", latest.String()), "release.yaml")
+	}
+
+	releaseYAML, err := ioutil.ReadFile(releasePath)
+	if err != nil {
+		return nil, "", microerror.Mask(err)
+	}
+
+	err = yaml.Unmarshal(releaseYAML, &release)
+	if err != nil {
+		return nil, "", microerror.Mask(err)
+	}
+
+	// Get info about the branch of azure operator being tested.
+	var headSHA string
+	var azureOperatorVersion string
+	{
+		headSHA, err = git.HeadSHA(r.flag.AzureOperator)
+		if err != nil {
+			return nil, "", microerror.Mask(err)
+		}
+
+		f, err := os.Open(filepath.Join(r.flag.AzureOperator, "pkg/project/project.go"))
+		if err != nil {
+			return nil, "", microerror.Mask(err)
+		}
+		defer f.Close()
+
+		// We want to extract the "5.2.1-dev" part (without quotes) from the following line:
+		// \tversion            = "5.2.1-dev"
+		re := regexp.MustCompile(`^\t*\s*\t*version\s*=\s*"([^"]*)".*$`)
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			matches := re.FindStringSubmatch(scanner.Text())
+			if len(matches) == 2 {
+				azureOperatorVersion = matches[1]
+				break
+			}
+		}
+	}
+
+	// Override the azure operator component.
+	for i, c := range release.Spec.Components {
+		if c.Name == "azure-operator" {
+			release.Spec.Components[i].Version = azureOperatorVersion
+			release.Spec.Components[i].Catalog = "control-plane-test-catalog"
+			release.Spec.Components[i].Reference = fmt.Sprintf("%s-%s", c.Version, headSHA)
+			break
+		}
+	}
+
+	// TODO update other components based on the requests file.
+
+	return &release, provider, nil
+}

--- a/cmd/create/release/mode_releases.go
+++ b/cmd/create/release/mode_releases.go
@@ -1,0 +1,62 @@
+package release
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/standup/pkg/git"
+)
+
+func (r *runner) generateReleaseFromReleasesRepo(ctx context.Context) (*v1alpha1.Release, string, error) {
+	var release v1alpha1.Release
+	var provider string
+	r.logger.LogCtx(ctx, "message", "determining release to test")
+	{
+		var releasePath string
+		{
+			// Tekton checks out the current commit in detached HEAD state with --depth=1.
+			// This means we need to fetch origin/master before we can determine the changed files.
+			err := git.Fetch(r.flag.Releases)
+			if err != nil {
+				return nil, "", microerror.Mask(err)
+			}
+
+			mergeBase, err := git.MergeBase(r.flag.Releases)
+			if err != nil {
+				return nil, "", microerror.Mask(err)
+			}
+
+			// Use "git diff" to find the release under test
+			diff, err := git.Diff(r.flag.Releases, mergeBase)
+			if err != nil {
+				return nil, "", microerror.Mask(err)
+			}
+
+			// Parse the git diff to get the release file, version, and provider
+			releasePath, provider, err = findReleaseInDiff(diff)
+			if err != nil {
+				return nil, "", microerror.Mask(err)
+			}
+			releasePath = filepath.Join(r.flag.Releases, releasePath)
+		}
+
+		r.logger.LogCtx(ctx, "message", "determined target release to test is "+releasePath)
+
+		releaseYAML, err := ioutil.ReadFile(releasePath)
+		if err != nil {
+			return nil, "", microerror.Mask(err)
+		}
+
+		err = yaml.Unmarshal(releaseYAML, &release)
+		if err != nil {
+			return nil, "", microerror.Mask(err)
+		}
+	}
+
+	return &release, provider, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.0
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/errors v0.2.3

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -55,6 +55,20 @@ func MergeBase(dir string) (string, error) {
 	return strings.TrimSpace(mergeBase), nil
 }
 
+func HeadSHA(dir string) (string, error) {
+	// Get repo's HEAD SHA.
+	argsArr := []string{
+		"rev-parse",
+		"HEAD",
+	}
+	repoName, err := runGit(argsArr, dir)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return strings.TrimSpace(repoName), nil
+}
+
 func runGit(args []string, dir string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14534

This PR adds a new flag `--mode` to the `create release` command.

The flag can be either `releases` or `azure-operator`.

If `releases`, the behaviour is the same as before.
If `azure-operator`, the `release` CR is created by copying the latest release available in the passed `releases` repo for `azure` and updating `azure-operator` component to the sha version of the passed repository.