### PR TITLE
Select random organization when creating cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.4.0] - 2021-01-19
+### Changed
 
+- The organization that owns the created cluster is chosen randomly among the existing organizations that contain the `giantswarm.io/conformance-testing` label.
+
+## [2.4.0] - 2021-01-19
 
 ### Added
 

--- a/cmd/create/cluster/error.go
+++ b/cmd/create/cluster/error.go
@@ -19,3 +19,12 @@ var invalidFlagError = &microerror.Error{
 func IsInvalidFlag(err error) bool {
 	return microerror.Cause(err) == invalidFlagError
 }
+
+var notAvailableOrganizationError = &microerror.Error{
+	Kind: "notAvailableOrganizationError",
+}
+
+// IsNotAvailableOrganization asserts notAvailableOrganizationError.
+func IsNotAvailableOrganization(err error) bool {
+	return microerror.Cause(err) == notAvailableOrganizationError
+}

--- a/cmd/create/cluster/flag.go
+++ b/cmd/create/cluster/flag.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	flagConfig   = "config"
-	flagOutput   = "output"
-	flagProvider = "provider"
-	flagRelease  = "release"
+	flagConfig     = "config"
+	flagKubeconfig = "kubeconfig"
+	flagOutput     = "output"
+	flagProvider   = "provider"
+	flagRelease    = "release"
 )
 
 type flag struct {
@@ -25,6 +26,7 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Config, flagConfig, "g", "", `The path to the file containing API endpoints and tokens for each provider.`)
+	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the directory containing the kubeconfigs for provider control planes.`)
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", `The directory in which to store the cluster ID, kubeconfig, and provider of the created cluster.`)
 	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", `The provider of the target control plane.`)
 	cmd.Flags().StringVarP(&f.Release, flagRelease, "r", "", `The semantic version of the release to be tested.`)

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/apimachinery v0.18.9
 	k8s.io/client-go v0.18.9
 	k8s.io/utils v0.0.0-20200731180307-f00132d28269 // indirect
+	sigs.k8s.io/controller-runtime v0.6.4
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -983,6 +983,8 @@ sigs.k8s.io/controller-runtime v0.6.1 h1:LcK2+nk0kmaOnKGN+vBcWHqY5WDJNJNB/c5pW+s
 sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gEORz0efEja7A=
 sigs.k8s.io/controller-runtime v0.6.3 h1:SBbr+inLPEKhvlJtrvDcwIpm+uhDvp63Bl72xYJtoOE=
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
+sigs.k8s.io/controller-runtime v0.6.4 h1:4013CKsBs5bEqo+LevzDett+LLxag/FjQWG94nVZ/9g=
+sigs.k8s.io/controller-runtime v0.6.4/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802/go.mod h1:HIZ3PWUezpklcjkqpFbnYOqaqsAE1JeCTEwkgvPLXjk=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/pkg/gsclient/cluster.go
+++ b/pkg/gsclient/cluster.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/standup/pkg/key"
 )
 
-func (c *Client) CreateCluster(ctx context.Context, releaseVersion string) (string, error) {
+func (c *Client) CreateCluster(ctx context.Context, organizationName, releaseVersion string) (string, error) {
 	err := c.authenticate(ctx)
 	if err != nil {
 		return "", microerror.Mask(err)
@@ -17,7 +17,7 @@ func (c *Client) CreateCluster(ctx context.Context, releaseVersion string) (stri
 
 	createOptions := GsctlCreateClusterOptions{
 		OutputType: OutputTypeJSON,
-		Owner:      key.ClusterOwnerName,
+		Owner:      organizationName,
 		Name:       releaseVersion,
 		Release:    releaseVersion,
 	}


### PR DESCRIPTION
We were being throttled by Azure due to the high number of clusters being created on our subscription. Using different organizations for the created clusters can help in this regard, because different organizations may use different subscriptions.

Also, by selecting different organizations we can test the BYOC scenario, with organizations using different subscriptions than the management cluster.

For the implementation, I listed the `Organization` objects in the management cluster labeled in a certain way. If we want an organization to be used for conformance testing, we just need to add that label to it and it'd be picked up.

## Checklist

- [X] Update changelog in CHANGELOG.md.
