### PR TITLE
Use latest release next patch when creating release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use "latest release" next patch version when creating new release for testing an operator.
+
 ## [2.5.0] - 2021-01-26
 
 ### Changed

--- a/cmd/create/testoperatorrelease/runner.go
+++ b/cmd/create/testoperatorrelease/runner.go
@@ -76,10 +76,19 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		return microerror.Mask(err)
 	}
 
+	// If latest release is `v14.1.0`, the created release needs to be newer so
+	// it can't be `v14.1.0-something`, it needs to be at least `v14.1.1-something`.
+	version, err := semver.NewVersion(release.Name)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	nextPatch := version.IncPatch()
+
 	// Randomize the name to avoid duplicate names.
 	{
 		originalName := release.Name
-		release.Name = generateReleaseName(release.Name)
+		release.Name = generateReleaseName(fmt.Sprintf("v%s", nextPatch.String()))
 		releaseVersion := strings.TrimPrefix(release.Name, "v")
 		r.logger.LogCtx(ctx, "message", fmt.Sprintf("testing release %s for %s as %s", strings.TrimPrefix(originalName, "v"), provider, releaseVersion))
 	}


### PR DESCRIPTION
When creating a new release to test an operator we need to use a newer version than latest or we won't be able to upgrade to it, because admission controller prevents upgrading. To avoid the following error

```
Error from server (BadRequest): admission webhook "validate.cluster.update.azure-admission-controller-unique.giantswarm.io" denied the request: downgrading is not allowed error: downgrading is not allowed (attempted to downgrade from 14.1.0 to 14.1.0-1613059489)
```

our created release should've been `14.1.1-1613059489`.

## Checklist

- [X] Update changelog in CHANGELOG.md.
