### PR TITLE
Check the cluster namespace deletion from cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Check the cluster namespace deletion from a cleanup task.
+
 ### Fixed
 
 - Wait for KVMConfig deletion before deleting release (KVM only).

--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -209,9 +209,8 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 	}
 	r.logger.LogCtx(ctx, "message", "deleted release CR")
 
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("checking the namespace %#q deletion", r.flag.ClusterID))
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("deleting namespace %#q", r.flag.ClusterID))
 	{
-		r.logger.LogCtx(ctx, "message", fmt.Sprintf("waiting the namespace %#q deletion", r.flag.ClusterID))
 		{
 			// Wait for the cluster namespace to be deleted
 			o := func() error {
@@ -231,7 +230,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 				return microerror.Mask(err)
 			}
 		}
-		r.logger.LogCtx(ctx, "message", fmt.Sprintf("the namespace %#q has been deleted", r.flag.ClusterID))
+		r.logger.LogCtx(ctx, "message", fmt.Sprintf("namespace %#q has been deleted", r.flag.ClusterID))
 	}
 
 	r.logger.LogCtx(ctx, "message", "teardown complete")

--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -207,6 +208,32 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		}
 	}
 	r.logger.LogCtx(ctx, "message", "deleted release CR")
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("checking the namespace %#q deletion", r.flag.ClusterID))
+	{
+		r.logger.LogCtx(ctx, "message", fmt.Sprintf("waiting the namespace %#q deletion", r.flag.ClusterID))
+		{
+			// Wait for the cluster namespace to be deleted
+			o := func() error {
+				_, err := k8sClient.K8sClient().CoreV1().Namespaces().Get(ctx, r.flag.ClusterID, v1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return nil
+				} else if err != nil {
+					return backoff.Permanent(err)
+				}
+				return microerror.Mask(notYetDeletedError)
+			}
+			// Retry basically forever, the tekton task will determine maximum runtime.
+			b := backoff.NewMaxRetries(^uint64(0), 20*time.Second)
+
+			err := backoff.Retry(o, b)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+		r.logger.LogCtx(ctx, "message", fmt.Sprintf("the namespace %#q has been deleted", r.flag.ClusterID))
+	}
+
 	r.logger.LogCtx(ctx, "message", "teardown complete")
 
 	return nil

--- a/cmd/cleanup/runner.go
+++ b/cmd/cleanup/runner.go
@@ -209,7 +209,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 	}
 	r.logger.LogCtx(ctx, "message", "deleted release CR")
 
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("deleting namespace %#q", r.flag.ClusterID))
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("waiting for %#q namespace deletion", r.flag.ClusterID))
 	{
 		{
 			// Wait for the cluster namespace to be deleted


### PR DESCRIPTION
Toward: https://github.com/giantswarm/giantswarm/issues/13971
> My idea is to update codes here to check whether cluster namespace has been deleted, rather than check the kubeconfig secret or app CRs deletion individually.

## Checklist

- [x] Update changelog in CHANGELOG.md.
