### PR TITLE
Avoid creating and deleting a test release for CAPI releases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid creating and deleting a test release for CAPI releases. 
+
 ## [3.0.0] - 2021-07-13
 
 ## Added

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -52,6 +52,10 @@ func GetPipelineConfigByName(pipelineName string) (bool, PipelineConfig) {
 	return ok, PipelineConfig{}
 }
 
+func IsCapiRelease(releaseName string) bool {
+	return releaseName == "v20.0.0" || releaseName == "20.0.0"
+}
+
 func KubeconfigPath(base, provider string) (path string) {
 	return fmt.Sprintf("%s/%s", base, provider)
 }


### PR DESCRIPTION
First steps towards making the test infra work with CAPI clusters.
This PR avoids creating (and deleting) a temporary test release in case the release being tested is a CAPI one.

## Checklist

- [x] Update changelog in CHANGELOG.md.
