### PR TITLE
Add flag to specify the expected number of nodes to be ready in `wait ready` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add flag to specify the expected number of nodes to be ready in `wait ready` command.
+
 ## [3.1.0] - 2021-09-16
 
 ### Changed

--- a/cmd/wait/flag.go
+++ b/cmd/wait/flag.go
@@ -6,18 +6,22 @@ import (
 )
 
 const (
-	flagKubeconfig = "kubeconfig"
-	flagProvider   = "provider"
+	flagKubeconfig        = "kubeconfig"
+	flagProvider          = "provider"
+	flagDesiredNodesCount = "nodes"
 )
 
 type flag struct {
-	Kubeconfig string
-	Provider   string
+	Kubeconfig        string
+	Provider          string
+	DesiredNodesCount int
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Kubeconfig, flagKubeconfig, "k", "", `The path to the kubeconfig for the tenant cluster.`)
 	cmd.Flags().StringVarP(&f.Provider, flagProvider, "p", "", `The provider of the target control plane.`)
+	cmd.Flags().IntVarP(&f.DesiredNodesCount, flagDesiredNodesCount, "", 2, `The number of nodes to wait for.`)
+
 }
 
 func (f *flag) Validate() error {
@@ -26,6 +30,9 @@ func (f *flag) Validate() error {
 	}
 	if f.Provider == "" {
 		return microerror.Maskf(invalidFlagError, "--%s is required", flagProvider)
+	}
+	if f.DesiredNodesCount < 2 {
+		return microerror.Maskf(invalidFlagError, "--%s has to be bigger than 1", flagDesiredNodesCount)
 	}
 
 	return nil

--- a/cmd/wait/runner.go
+++ b/cmd/wait/runner.go
@@ -117,8 +117,8 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 					}
 				}
 			}
-			if nodeCount < 2 {
-				message := fmt.Sprintf("found %d registered nodes, waiting for at least 2", nodeCount)
+			if nodeCount < r.flag.DesiredNodesCount {
+				message := fmt.Sprintf("found %d registered nodes, waiting for at least %d", nodeCount, r.flag.DesiredNodesCount)
 				r.logger.LogCtx(ctx, "message", message)
 				return microerror.Mask(notReadyError)
 			}


### PR DESCRIPTION
This allows for more reliable tests

## Checklist

- [x] Update changelog in CHANGELOG.md.
