### PR TITLE
Add support to CAPI clusters in the `wait ready` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add flag to specify the expected number of nodes to be ready in `wait ready` command.
+- Add support to CAPI clusters in the `wait ready` command.
 
 ## [3.1.0] - 2021-09-16
 

--- a/cmd/wait/runner.go
+++ b/cmd/wait/runner.go
@@ -175,7 +175,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			}
 
 			if len(services.Items) == 0 {
-				message := fmt.Sprintf("CoreDNS service not found using label selector %#q", serviceLabelSelector)
+				message := fmt.Sprintf("CoreDNS service not found using label selectors %#q and %#q", serviceLabelSelector, alternateTargetLabels)
 				r.logger.LogCtx(ctx, "message", message)
 				return microerror.Mask(notReadyError)
 			}

--- a/cmd/wait/runner.go
+++ b/cmd/wait/runner.go
@@ -142,9 +142,16 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 	{
 		r.logger.LogCtx(ctx, "message", "waiting for CoreDNS to be ready")
 
+		// Legacy GS clusters.
 		targetLabels := map[string]string{
 			"kubernetes.io/cluster-service": "true",
 			"kubernetes.io/name":            "CoreDNS",
+		}
+
+		// CAPI clusters.
+		alternateTargetLabels := map[string]string{
+			"kubernetes.io/cluster-service": "true",
+			"kubernetes.io/name":            "KubeDNS",
 		}
 
 		o := func() error {
@@ -156,6 +163,17 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 				r.logger.LogCtx(ctx, "message", "error listing services", "error", err)
 				return microerror.Mask(err)
 			}
+			if len(services.Items) == 0 {
+				serviceLabelSelector := labelsToSelector(alternateTargetLabels)
+				services, err = k8sClient.CoreV1().Services("kube-system").List(ctx, v1.ListOptions{
+					LabelSelector: serviceLabelSelector,
+				})
+				if err != nil {
+					r.logger.LogCtx(ctx, "message", "error listing services", "error", err)
+					return microerror.Mask(err)
+				}
+			}
+
 			if len(services.Items) == 0 {
 				message := fmt.Sprintf("CoreDNS service not found using label selector %#q", serviceLabelSelector)
 				r.logger.LogCtx(ctx, "message", message)


### PR DESCRIPTION
Capi clusters and GS clusters use a different set of labels for the coredns service.
This PR allows detecting the fact coredns is running correctly for both label sets.

## Checklist

- [x] Update changelog in CHANGELOG.md.
