### PR TITLE
Remove obsolete go-test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,9 @@ orbs:
 workflows:
   test:
     jobs:
-      - architect/go-test:
-          name: go-test
-          filters:
-            # Trigger job also on git tag.
-            tags:
-              only: /^v.*/
-
       - architect/go-build:
           name: go-build-standup
           binary: standup
-          requires:
-            - go-test
           # Needed to trigger job also on git tag.
           filters:
             tags:


### PR DESCRIPTION
`go-test` and `go-build` bot run unit tests. This PR removes the redundant step to save cost and resources.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
